### PR TITLE
[FIX] Establish basic compatibility for TYPO3 v11

### DIFF
--- a/Classes/Domain/Model/Dto/PdfDemand.php
+++ b/Classes/Domain/Model/Dto/PdfDemand.php
@@ -2,14 +2,14 @@
 declare(strict_types=1);
 namespace Extcode\CartPdf\Domain\Model\Dto;
 
+use TYPO3\CMS\Extbase\DomainObject\AbstractEntity;
 /*
  * This file is part of the package extcode/cart-pdf.
  *
  * For the full copyright and license information, please read the
  * LICENSE file that was distributed with this source code.
  */
-
-class PdfDemand extends \TYPO3\CMS\Extbase\DomainObject\AbstractEntity
+class PdfDemand extends AbstractEntity
 {
     /**
      * @var int

--- a/Classes/EventListener/ProcessOrderCreate/DocumentRenderer.php
+++ b/Classes/EventListener/ProcessOrderCreate/DocumentRenderer.php
@@ -10,7 +10,7 @@ namespace Extcode\CartPdf\EventListener\ProcessOrderCreate;
  */
 
 use Extcode\Cart\Domain\Repository\Order\ItemRepository as OrderItemRepository;
-use Extcode\Cart\Event\ProcessOrderCreateEvent;
+use Extcode\Cart\Event\Order\NumberGeneratorEvent;
 use Extcode\Cart\Utility\OrderUtility;
 use Extcode\CartPdf\Service\PdfService;
 use TYPO3\CMS\Extbase\Persistence\Generic\PersistenceManager;
@@ -61,7 +61,7 @@ class DocumentRenderer
         $this->options = $options;
     }
 
-    public function __invoke(ProcessOrderCreateEvent $event): void
+    public function __invoke(NumberGeneratorEvent $event): void
     {
         $orderItem = $event->getOrderItem();
         $this->settings = $event->getSettings();
@@ -82,9 +82,7 @@ class DocumentRenderer
                 $setterForDate = 'set' . ucfirst($documentType) . 'Date';
 
                 if (!$orderItem->$getterForNumber()) {
-                    $documentNumber = $this->orderUtility->getNumber($this->settings, $documentType);
-
-                    $orderItem->$setterForNumber($documentNumber);
+                    $orderItem->$setterForNumber($orderItem->getOrderNumber());
                     $orderItem->$setterForDate(new \DateTime());
                 }
 

--- a/Classes/Service/PdfService.php
+++ b/Classes/Service/PdfService.php
@@ -118,7 +118,7 @@ class PdfService
         $newFileName = $orderItem->$getNumber() . '.pdf';
 
         if (file_exists($pdfFilename)) {
-            $storage = $this->storageRepository->findByUid($this->pdfSettings['storageRepository']);
+            $storage = $this->storageRepository->findByUid(intval($this->pdfSettings['storageRepository']));
             $targetFolder = $storage->getFolder($this->pdfSettings['storageFolder']);
 
             if (class_exists('\TYPO3\CMS\Core\Resource\DuplicationBehavior')) {

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -14,9 +14,9 @@ services:
     tags:
       - name: event.listener
         identifier: 'cart-pdf--process-order-create--document-renderer'
-        event: Extcode\Cart\Event\ProcessOrderCreateEvent
-        after: 'cart--process-order-create--order-number'
-        before: 'cart--process-order-create--email'
+        event: Extcode\Cart\Event\Order\NumberGeneratorEvent
+        after: 'cart--order--create--invoice-number'
+        before: 'cart--order--finish--email'
 
   Extcode\CartPdf\Service\PdfService:
     arguments:

--- a/Configuration/TCA/Overrides/sys_template.php
+++ b/Configuration/TCA/Overrides/sys_template.php
@@ -1,5 +1,5 @@
 <?php
-defined('TYPO3_MODE') or die();
+defined('TYPO3') or die();
 
 call_user_func(function () {
     \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addStaticFile(

--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,7 @@
         "PDF",
         "cart"
     ],
+    "version": "6.0.0",
     "authors": [
         {
             "name": "Daniel Gohlke",
@@ -42,17 +43,14 @@
     },
     "require": {
         "php": ">=7.2.0 <7.5",
-        "typo3/cms-core": "^10.4",
-        "extcode/cart": "^7.0",
-        "extcode/tcpdf": "^3.0"
+        "typo3/cms-core": "^11.5",
+        "extcode/cart": "^8.0",
+        "extcode/tcpdf": "^4.0.0"
     },
     "require-dev": {
         "typo3/testing-framework": "^5.0",
         "friendsofphp/php-cs-fixer": "^2.14",
         "helmich/typo3-typoscript-lint": "^2.0"
-    },
-    "replace": {
-        "extcode/cart-pdf": "self.version"
     },
     "scripts": {
         "post-autoload-dump": [

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -17,12 +17,12 @@ $EM_CONF['cart_pdf'] = [
     'modify_tables' => '',
     'clearCacheOnLoad' => 0,
     'lockType' => '',
-    'version' => '5.0.0',
+    'version' => '6.0.0',
     'constraints' => [
         'depends' => [
-            'typo3' => '10.4.0-10.4.99',
-            'cart' => '7.0.0',
-            'tcpdf' => '3.0.0',
+            'typo3' => '11.5.0-11.5.99',
+            'cart' => '8.0.0',
+            'tcpdf' => '4.0.0',
         ],
         'conflicts' => [],
         'suggests' => [],


### PR DESCRIPTION
I've done some basic stuff to make this extension usable with TYPO3 v11.5 and EXT:cart v.8.2.0.
(I had to add a version to composer.json, otherwise I could't use it.)

Testet with:

PayPal sandbox
PHP 7.4.
TYPO3 11.5.6
EXT:cart 8.2.0
EXT:cart_products 4.0.3